### PR TITLE
Raise default GCS upload ChunkSize to 16MB

### DIFF
--- a/googleapi/googleapi.go
+++ b/googleapi/googleapi.go
@@ -54,7 +54,7 @@ const (
 
 	// DefaultUploadChunkSize is the default chunk size to use for resumable
 	// uploads if not specified by the user.
-	DefaultUploadChunkSize = 8 * 1024 * 1024
+	DefaultUploadChunkSize = 16 * 1024 * 1024
 
 	// MinUploadChunkSize is the minimum chunk size that can be used for
 	// resumable uploads.  All user-specified chunk sizes must be multiple of


### PR DESCRIPTION
The sweet spot for uploading larger objects to GCS is using a ChunkSize around 16 MB. The default is currently 8MB. For larger (100MB) objects, uploaded from GCE, this results in a 10% performance improvement. I propose 16MB, rather than the 15MB chosen for the Java API, as it aligns nicely with 8MB boundaries.

This issue is similar to
googleapis/java-core#86
Credit to @domZippilli for doing the research.